### PR TITLE
fix pigpiod

### DIFF
--- a/docker-compose.yaml.example
+++ b/docker-compose.yaml.example
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   terrariumpi:
-    image: wkd1/test:new-slim-22
+    image: wkd1/test:new-slim-23
     volumes:
       - /opt/terrariumpi/logs:/TerrariumPI/log
       - /opt/terrariumpi/data:/TerrariumPI/data

--- a/run.sh
+++ b/run.sh
@@ -95,5 +95,8 @@ if [[ $REBOOT_REQUIRED == 1 ]]; then
   fi
 fi
 
+# run localhost socket only
+pigpiod -l
+
 # No reboot required, Pi must already be fully configured, start TP
 exec /opt/venv/bin/python /TerrariumPI/terrariumPI.py


### PR DESCRIPTION
```
pigpio V79
Usage: sudo pigpiod [OPTION] ...
   -a value,   DMA mode, 0=AUTO, 1=PMAP, 2=MBOX,  default AUTO
   -b value,   sample buffer size in ms,          default 120
   -c value,   library internal settings,         default 0
   -d value,   primary DMA channel, 0-14,         default 14
   -e value,   secondary DMA channel, 0-14,       default 6
   -f,         disable fifo interface,            default enabled
   -g,         run in foreground (do not fork),   default disabled
   -k,         disable socket interface,          default enabled
   -l,         localhost socket only              default local+remote
   -m,         disable alerts                     default enabled
   -n IP addr, allow address, name or dotted,     default allow all
   -p value,   socket port, 1024-32000,           default 8888
   -s value,   sample rate, 1, 2, 4, 5, 8, or 10, default 5
   -t value,   clock peripheral, 0=PWM 1=PCM,     default PCM
   -v, -V,     display pigpio version and exit
   -x mask,    GPIO which may be updated,         default board GPIO
```